### PR TITLE
Add 7-Zip file type for backups & config option

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,12 +8,14 @@ buildscript {
 	dependencies {
 		classpath group: 'net.minecraftforge.gradle', name: 'ForgeGradle', version: '3.+', changing: true
 		classpath 'gradle.plugin.com.matthewprenger:CurseGradle:1.1.0'
+		classpath 'com.github.jengelman.gradle.plugins:shadow:2.0.3'
 	}
 }
 apply plugin: 'net.minecraftforge.gradle'
 apply plugin: 'eclipse'
 apply plugin: 'com.matthewprenger.cursegradle'
 apply plugin: 'maven'
+apply plugin: 'com.github.johnrengelman.plugin-shadow'
 
 apply from: 'https://files.latmod.com/public/markdown-git-changelog.gradle'
 
@@ -75,11 +77,20 @@ minecraft {
 	}
 }
 
+configurations {
+	shade
+	implementation.extendsFrom shade
+}
+
 dependencies {
 	minecraft "net.minecraftforge:forge:${forge_version}"
+
+	shade 'org.apache.commons:commons-compress:1.21'
+	shade 'org.tukaani:xz:1.9'
 }
 
 jar {
+	setClassifier('slim')
 	manifest {
 		attributes([
 				"Specification-Title"     : project.mod_id,
@@ -93,10 +104,16 @@ jar {
 	}
 }
 
-def reobfFile = file("$buildDir/reobfJar/output.jar")
-def reobfArtifact = artifacts.add('default', reobfFile) {
-	type 'jar'
-	builtBy 'reobfJar'
+shadowJar {
+	setClassifier(null)
+	configurations = [project.configurations.shade]
+	finalizedBy 'reobfShadowJar'
+}
+
+assemble.dependsOn(shadowJar)
+
+reobf {
+	shadowJar {}
 }
 
 if (ENV.CURSEFORGE_KEY) {
@@ -104,6 +121,7 @@ if (ENV.CURSEFORGE_KEY) {
 		apiKey = ENV.CURSEFORGE_KEY
 		project {
 			id = project.curseforge_id
+			mainArtifact reobfShadowJar
 			releaseType = project.curseforge_type
 			addGameVersion '1.16.5'
 			changelog = getGitChangelog

--- a/src/main/java/com/feed_the_beast/mods/ftbbackups/FTBBackupsConfig.java
+++ b/src/main/java/com/feed_the_beast/mods/ftbbackups/FTBBackupsConfig.java
@@ -19,6 +19,7 @@ public class FTBBackupsConfig
 	public static int backupsToKeep;
 	public static long backupTimer;
 	public static int compressionLevel;
+	public static boolean use7ZipInstead;
 	public static String folder;
 	public static boolean displayFileSize;
 	public static List<String> extraFiles;
@@ -57,6 +58,7 @@ public class FTBBackupsConfig
 		backupsToKeep = cfg.backupsToKeep.get();
 		backupTimer = cfg.backupTimer.get() * 60000L;
 		compressionLevel = cfg.compressionLevel.get();
+		use7ZipInstead = cfg.use7zipInstead.get();
 		folder = cfg.folder.get();
 		displayFileSize = cfg.displayFileSize.get();
 		extraFiles = new ArrayList<>(cfg.extraFiles.get());
@@ -96,6 +98,7 @@ public class FTBBackupsConfig
 		private final ForgeConfigSpec.IntValue backupsToKeep;
 		private final ForgeConfigSpec.IntValue backupTimer;
 		private final ForgeConfigSpec.IntValue compressionLevel;
+		private final ForgeConfigSpec.BooleanValue use7zipInstead;
 		private final ForgeConfigSpec.ConfigValue<String> folder;
 		private final ForgeConfigSpec.BooleanValue displayFileSize;
 		private final ForgeConfigSpec.ConfigValue<List<? extends String>> extraFiles;
@@ -144,6 +147,11 @@ public class FTBBackupsConfig
 					)
 					.translation("ftbbackups.general.compression_level")
 					.defineInRange("compression_level", 1, 0, 9);
+
+			use7zipInstead = builder
+					.comment("Use 7-Zip archive instead of ZIP archive for backup files.")
+					.translation("ftbbackups.general.use_7zip_instead")
+					.define("use_7zip_instead", false);
 
 			folder = builder
 					.comment("Absolute path to backups folder.")

--- a/src/main/resources/assets/ftbbackups/lang/en_us.json
+++ b/src/main/resources/assets/ftbbackups/lang/en_us.json
@@ -6,6 +6,7 @@
 	"ftbbackups.general.backups_to_keep": "Backups to Keep",
 	"ftbbackups.general.backup_timer": "Backup Timer",
 	"ftbbackups.general.compression_level": "Compression Level",
+	"ftbbackups.general.use_7zip_instead": "Use .7z File Type",
 	"ftbbackups.general.folder": "Folder",
 	"ftbbackups.general.display_file_size": "Display File Size",
 	"ftbbackups.general.use_separate_thread": "Use Separate Thread",


### PR DESCRIPTION
This PR adds the option (disabled by default) to create 7-Zip archive files instead of ZIP files for world backups. From my testing, this compression method always creates smaller backup files than ZIP, so with this PR, server hosts can save more space on their hard drives.
Downsides of this PR are that .7z backups take longer to create than .zip, and the library I chose to do the .7z compression must be shaded into FTB-Backups, which I have added in the build.gradle of this PR. I could not test the curseforge publishing task, but building the jar normally works fine in-game.
If necessary, I can update this PR to the 1.18+ version of FTB-Backups whenever that releases.